### PR TITLE
Support content-type based responses

### DIFF
--- a/api/hello.ts
+++ b/api/hello.ts
@@ -1,8 +1,16 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 
 export default function handler(req: VercelRequest, res: VercelResponse) {
-  const { name = 'World' } = req.query
-  return res.json({
-    message: `Hello ${name}!`,
-  })
+  const { name = 'there' } = req.query
+  const acceptHeader = req.headers['accept']
+  
+  if (acceptHeader?.includes('text/plain')) {
+    res.setHeader('Content-Type', 'text/plain')
+    return res.send(`Hi ${name}!`)
+  } else {
+    res.setHeader('Content-Type', 'application/json')
+    return res.json({
+      message: `Hi ${name}!`,
+    })
+  }
 }


### PR DESCRIPTION
Related to #1

Updates the `handler` function in `api/hello.ts` to respond with greetings based on the `Accept` header.
- Checks the `Accept` header to determine if the client prefers a `text/plain` or `application/json` response.
- Implements conditional logic to support both JSON and plain text responses, enhancing the API's flexibility.
- Customizes the greeting message using the `name` query parameter for both response formats, defaulting to 'there' if no name is provided.
- Sets the appropriate `Content-Type` response header based on the determined response format.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/atian25/nodejs-serverless-function/issues/1?shareId=5ec68c23-dd24-438f-8e45-989e6c4b3385).